### PR TITLE
🐛 fix: fix and enable pep622 

### DIFF
--- a/pyfuture/codemod/transform_match.py
+++ b/pyfuture/codemod/transform_match.py
@@ -90,6 +90,7 @@ def match_transform(
     if root_if.orelse is None:
         return root_if.with_changes(orelse=match_selector(left, case))
     else:
+        assert isinstance(root_if.orelse, cst.If)
         return root_if.with_changes(
             orelse=match_transform(
                 left=left,
@@ -184,12 +185,14 @@ class TransformMatchCommand(VisitorBasedCodemodCommand):
             else:
                 root_if = match_selector(body.subject, zero_case)
                 for cs in body.cases[1:]:
+                    assert isinstance(root_if, cst.If)
                     root_if = match_transform(
                         body.subject,
                         cs,
                         root_if,
                     )
 
+                assert isinstance(root_if, cst.If)
                 # replace match
                 replacemences[node] = replace_match_node(
                     body_scope,

--- a/pyfuture/codemod/transform_match.py
+++ b/pyfuture/codemod/transform_match.py
@@ -142,7 +142,7 @@ def replace_match_node(
     zero_case: cst.MatchCase,
     root_if: cst.If | None = None,
 ) -> FunctionDef:
-    new_body_code = list(body_scope.node.body.body)
+    new_body_code: list[cst.CSTNode] = list(body_scope.node.body.body)
     index: int = new_body_code.index(match_body)
     del new_body_code[index]
     if root_if is None:

--- a/pyfuture/utils.py
+++ b/pyfuture/utils.py
@@ -40,7 +40,7 @@ def transfer_code(
     if target[1] < 10:
         transformers.extend(
             [
-                # TransformMatchCommand(CodemodContext()),
+                TransformMatchCommand(CodemodContext()),
             ]
         )
     # TODO: Add more codemods here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ required-imports = ["from __future__ import annotations"]
 include = ["pyfuture"]
 exclude = [
     "pdm_build.py",
-    "pyfuture/codemod/transform_match.py"
+    # "pyfuture/codemod/transform_match.py"
 ]
 
 [tool.pdm.dev-dependencies]


### PR DESCRIPTION
简单支持match，需要支持`MatchOr`才能打开`match_op_selector`，但现在整体还不是很复杂，所以可以暂时直接使用`cst.Equal()`